### PR TITLE
Fixed routers failing to save when cable tier is null.

### DIFF
--- a/src/main/java/com/matyrobbrt/mirouters/MIRouters.java
+++ b/src/main/java/com/matyrobbrt/mirouters/MIRouters.java
@@ -68,7 +68,11 @@ public class MIRouters {
                 public Tag write(EnergyStorage attachment, HolderLookup.Provider provider) {
                     final CompoundTag tag = new CompoundTag();
                     tag.putLong("energy", attachment.getAmount());
-                    tag.putString("tier", attachment.getTier().name);
+                    
+                    final CableTier tier = attachment.getTier();
+                    if (tier != null) {
+                        tag.putString("tier", tier.name);
+                    }
                     return tag;
                 }
 


### PR DESCRIPTION
Routers will fail to save when the cable teir is null due to NRE while accessing the name property as experienced while playing Craftoria 1.7.1.